### PR TITLE
Builds ids

### DIFF
--- a/src/lib/Hydra/Controller/Job.pm
+++ b/src/lib/Hydra/Controller/Job.pm
@@ -82,7 +82,7 @@ sub overview : Chained('job') PathPart('') Args(0) {
     # If this is an aggregate job, then get its constituents.
     my @constituents = $c->model('DB::Builds')->search(
         { aggregate => { -in => $job->builds->search({}, { columns => ["id"], order_by => "id desc", rows => 15 })->as_query } },
-        { join => 'aggregateconstituents_constituents', 
+        { join => 'aggregateconstituents_constituents',
           columns => ['id', 'job', 'finished', 'buildstatus'],
           +select => ['aggregateconstituents_constituents.aggregate'],
           +as => ['aggregate']
@@ -99,7 +99,7 @@ sub overview : Chained('job') PathPart('') Args(0) {
 
     foreach my $agg (keys %$aggregates) {
         # FIXME: could be done in one query.
-        $aggregates->{$agg}->{build} = 
+        $aggregates->{$agg}->{build} =
             $c->model('DB::Builds')->find({id => $agg}, {columns => [@buildListColumns]}) or die;
     }
 
@@ -172,7 +172,7 @@ sub get_builds : Chained('job') PathPart('') CaptureArgs(0) {
     my ($self, $c) = @_;
     $c->stash->{allBuilds} = $c->stash->{job}->builds;
     $c->stash->{latestSucceeded} = $c->model('DB')->resultset('LatestSucceededForJob')
-        ->search({}, {bind => [$c->stash->{project}->name, $c->stash->{jobset}->name, $c->stash->{job}->name]});
+        ->search({}, {bind => [$c->stash->{jobset}->name, $c->stash->{job}->name]});
     $c->stash->{channelBaseName} =
         $c->stash->{project}->name . "-" . $c->stash->{jobset}->name . "-" . $c->stash->{job}->name;
 }

--- a/src/lib/Hydra/Controller/Jobset.pm
+++ b/src/lib/Hydra/Controller/Jobset.pm
@@ -162,7 +162,7 @@ sub get_builds : Chained('jobsetChain') PathPart('') CaptureArgs(0) {
     my ($self, $c) = @_;
     $c->stash->{allBuilds} = $c->stash->{jobset}->builds;
     $c->stash->{latestSucceeded} = $c->model('DB')->resultset('LatestSucceededForJobset')
-        ->search({}, {bind => [$c->stash->{project}->name, $c->stash->{jobset}->name]});
+        ->search({}, {bind => [$c->stash->{jobset}->name]});
     $c->stash->{channelBaseName} =
         $c->stash->{project}->name . "-" . $c->stash->{jobset}->name;
 }

--- a/src/lib/Hydra/Schema/Builds.pm
+++ b/src/lib/Hydra/Schema/Builds.pm
@@ -67,7 +67,7 @@ __PACKAGE__->table("Builds");
 
   data_type: 'integer'
   is_foreign_key: 1
-  is_nullable: 1
+  is_nullable: 0
 
 =head2 job
 
@@ -216,7 +216,7 @@ __PACKAGE__->add_columns(
   "jobset",
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "jobset_id",
-  { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
   "job",
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "nixname",
@@ -460,12 +460,7 @@ __PACKAGE__->belongs_to(
   "jobset",
   "Hydra::Schema::Jobsets",
   { id => "jobset_id" },
-  {
-    is_deferrable => 0,
-    join_type     => "LEFT",
-    on_delete     => "CASCADE",
-    on_update     => "NO ACTION",
-  },
+  { is_deferrable => 0, on_delete => "CASCADE", on_update => "NO ACTION" },
 );
 
 =head2 jobset_project_jobset
@@ -572,8 +567,8 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-05 15:02:29
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Mue0PFHuSYoyTm+PzgL22w
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-05 15:25:24
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:X7TLgc6bDD/sxsFJOv+SPA
 
 __PACKAGE__->has_many(
   "dependents",

--- a/src/lib/Hydra/Schema/Builds.pm
+++ b/src/lib/Hydra/Schema/Builds.pm
@@ -63,6 +63,12 @@ __PACKAGE__->table("Builds");
   is_foreign_key: 1
   is_nullable: 0
 
+=head2 jobset_id
+
+  data_type: 'integer'
+  is_foreign_key: 1
+  is_nullable: 1
+
 =head2 job
 
   data_type: 'text'
@@ -209,6 +215,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "jobset",
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
+  "jobset_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
   "job",
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "nixname",
@@ -451,6 +459,26 @@ Related object: L<Hydra::Schema::Jobsets>
 __PACKAGE__->belongs_to(
   "jobset",
   "Hydra::Schema::Jobsets",
+  { id => "jobset_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "CASCADE",
+    on_update     => "NO ACTION",
+  },
+);
+
+=head2 jobset_project_jobset
+
+Type: belongs_to
+
+Related object: L<Hydra::Schema::Jobsets>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "jobset_project_jobset",
+  "Hydra::Schema::Jobsets",
   { name => "jobset", project => "project" },
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "CASCADE" },
 );
@@ -544,8 +572,8 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-19 16:12:37
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:VjYbAQwv4THW2VfWQ5ajYQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-05 15:02:29
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Mue0PFHuSYoyTm+PzgL22w
 
 __PACKAGE__->has_many(
   "dependents",

--- a/src/lib/Hydra/Schema/Builds.pm
+++ b/src/lib/Hydra/Schema/Builds.pm
@@ -631,8 +631,8 @@ QUERY
 
 makeQueries('', "");
 makeQueries('ForProject', "and project = ?");
-makeQueries('ForJobset', "and project = ? and jobset = ?");
-makeQueries('ForJob', "and project = ? and jobset = ? and job = ?");
+makeQueries('ForJobset', "and jobset_id = (select id from jobsets j where j.name = ?)");
+makeQueries('ForJob', "and jobset_id = (select id from jobsets j where j.name = ?) and job = ?");
 
 
 my %hint = (

--- a/src/lib/Hydra/Schema/Jobs.pm
+++ b/src/lib/Hydra/Schema/Jobs.pm
@@ -47,6 +47,12 @@ __PACKAGE__->table("Jobs");
   is_foreign_key: 1
   is_nullable: 0
 
+=head2 jobset_id
+
+  data_type: 'integer'
+  is_foreign_key: 1
+  is_nullable: 1
+
 =head2 name
 
   data_type: 'text'
@@ -59,6 +65,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "jobset",
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
+  "jobset_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
   "name",
   { data_type => "text", is_nullable => 0 },
 );
@@ -130,6 +138,26 @@ Related object: L<Hydra::Schema::Jobsets>
 __PACKAGE__->belongs_to(
   "jobset",
   "Hydra::Schema::Jobsets",
+  { id => "jobset_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "CASCADE",
+    on_update     => "NO ACTION",
+  },
+);
+
+=head2 jobset_project_jobset
+
+Type: belongs_to
+
+Related object: L<Hydra::Schema::Jobsets>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "jobset_project_jobset",
+  "Hydra::Schema::Jobsets",
   { name => "jobset", project => "project" },
   { is_deferrable => 0, on_delete => "CASCADE", on_update => "CASCADE" },
 );
@@ -169,7 +197,7 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2015-07-30 16:52:20
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:vDAo9bzLca+QWfhOb9OLMg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-05 17:08:31
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:y0mcYGXRIQoHOuXWT0Kxtw
 
 1;

--- a/src/lib/Hydra/Schema/Jobs.pm
+++ b/src/lib/Hydra/Schema/Jobs.pm
@@ -195,4 +195,22 @@ __PACKAGE__->has_many(
 # Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-05 19:40:52
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:o6Iy66DCd39XyIiT5QkORQ
 
+=head2 builds
+
+Type: has_many
+
+Related object: L<Hydra::Sc2hema::Builds>
+
+=cut
+
+__PACKAGE__->has_many(
+  "builds",
+  "Hydra::Schema::Builds",
+  {
+    "foreign.job"     => "self.name",
+    "foreign.jobset_id"  => "self.jobset_id",
+  },
+  undef,
+);
+
 1;

--- a/src/lib/Hydra/Schema/Jobs.pm
+++ b/src/lib/Hydra/Schema/Jobs.pm
@@ -51,7 +51,7 @@ __PACKAGE__->table("Jobs");
 
   data_type: 'integer'
   is_foreign_key: 1
-  is_nullable: 1
+  is_nullable: 0
 
 =head2 name
 
@@ -66,7 +66,7 @@ __PACKAGE__->add_columns(
   "jobset",
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "jobset_id",
-  { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
   "name",
   { data_type => "text", is_nullable => 0 },
 );
@@ -139,12 +139,7 @@ __PACKAGE__->belongs_to(
   "jobset",
   "Hydra::Schema::Jobsets",
   { id => "jobset_id" },
-  {
-    is_deferrable => 0,
-    join_type     => "LEFT",
-    on_delete     => "CASCADE",
-    on_update     => "NO ACTION",
-  },
+  { is_deferrable => 0, on_delete => "CASCADE", on_update => "NO ACTION" },
 );
 
 =head2 jobset_project_jobset
@@ -197,7 +192,7 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-05 17:08:31
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:y0mcYGXRIQoHOuXWT0Kxtw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-05 19:40:52
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:o6Iy66DCd39XyIiT5QkORQ
 
 1;

--- a/src/lib/Hydra/Schema/Jobsets.pm
+++ b/src/lib/Hydra/Schema/Jobsets.pm
@@ -255,7 +255,7 @@ __PACKAGE__->has_many(
   undef,
 );
 
-=head2 jobs
+=head2 jobs_jobset_ids
 
 Type: has_many
 
@@ -264,7 +264,22 @@ Related object: L<Hydra::Schema::Jobs>
 =cut
 
 __PACKAGE__->has_many(
-  "jobs",
+  "jobs_jobset_ids",
+  "Hydra::Schema::Jobs",
+  { "foreign.jobset_id" => "self.id" },
+  undef,
+);
+
+=head2 jobs_project_jobsets
+
+Type: has_many
+
+Related object: L<Hydra::Schema::Jobs>
+
+=cut
+
+__PACKAGE__->has_many(
+  "jobs_project_jobsets",
   "Hydra::Schema::Jobs",
   {
     "foreign.jobset"  => "self.name",
@@ -373,8 +388,26 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-05 14:04:10
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:nYCuDZ8kEfmtUTbq4HGA1Q
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-05 19:28:13
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:UUR0srN7zKOyLEtqC9CavA
+
+=head2 jobs
+
+Type: has_many
+
+Related object: L<Hydra::Schema::Jobs>
+
+=cut
+
+__PACKAGE__->has_many(
+  "jobs",
+  "Hydra::Schema::Jobs",
+  {
+    "foreign.jobset"  => "self.name",
+    "foreign.project" => "self.project",
+  },
+  undef,
+);
 
 my %hint = (
     columns => [

--- a/src/lib/Hydra/Schema/Jobsets.pm
+++ b/src/lib/Hydra/Schema/Jobsets.pm
@@ -418,10 +418,7 @@ Related object: L<Hydra::Schema::Builds>
 __PACKAGE__->has_many(
   "builds",
   "Hydra::Schema::Builds",
-  {
-    "foreign.jobset"  => "self.name",
-    "foreign.project" => "self.project",
-  },
+  { "foreign.jobset_id" => "self.id" },
   undef,
 );
 

--- a/src/lib/Hydra/Schema/Jobsets.pm
+++ b/src/lib/Hydra/Schema/Jobsets.pm
@@ -436,10 +436,7 @@ Related object: L<Hydra::Schema::Jobs>
 __PACKAGE__->has_many(
   "jobs",
   "Hydra::Schema::Jobs",
-  {
-    "foreign.jobset"  => "self.name",
-    "foreign.project" => "self.project",
-  },
+  { "foreign.jobset_id" => "self.id" },
   undef,
 );
 

--- a/src/lib/Hydra/Schema/Jobsets.pm
+++ b/src/lib/Hydra/Schema/Jobsets.pm
@@ -237,7 +237,7 @@ __PACKAGE__->has_many(
   undef,
 );
 
-=head2 builds
+=head2 builds_jobset_ids
 
 Type: has_many
 
@@ -246,7 +246,22 @@ Related object: L<Hydra::Schema::Builds>
 =cut
 
 __PACKAGE__->has_many(
-  "builds",
+  "builds_jobset_ids",
+  "Hydra::Schema::Builds",
+  { "foreign.jobset_id" => "self.id" },
+  undef,
+);
+
+=head2 builds_project_jobsets
+
+Type: has_many
+
+Related object: L<Hydra::Schema::Builds>
+
+=cut
+
+__PACKAGE__->has_many(
+  "builds_project_jobsets",
   "Hydra::Schema::Builds",
   {
     "foreign.jobset"  => "self.name",
@@ -388,8 +403,27 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-05 19:28:13
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:UUR0srN7zKOyLEtqC9CavA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-05 19:31:24
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:pHK9N0tufWeIJo0LvxG2vA
+
+
+=head2 builds
+
+Type: has_many
+
+Related object: L<Hydra::Schema::Builds>
+
+=cut
+
+__PACKAGE__->has_many(
+  "builds",
+  "Hydra::Schema::Builds",
+  {
+    "foreign.jobset"  => "self.name",
+    "foreign.project" => "self.project",
+  },
+  undef,
+);
 
 =head2 jobs
 

--- a/src/lib/Hydra/Schema/Jobsets.pm
+++ b/src/lib/Hydra/Schema/Jobsets.pm
@@ -41,6 +41,11 @@ __PACKAGE__->table("Jobsets");
   is_foreign_key: 1
   is_nullable: 0
 
+=head2 id
+
+  data_type: 'serial'
+  is_nullable: 0
+
 =head2 project
 
   data_type: 'text'
@@ -144,6 +149,8 @@ __PACKAGE__->table("Jobsets");
 __PACKAGE__->add_columns(
   "name",
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
+  "id",
+  { data_type => "serial", is_nullable => 0 },
   "project",
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "description",
@@ -195,6 +202,20 @@ __PACKAGE__->add_columns(
 =cut
 
 __PACKAGE__->set_primary_key("project", "name");
+
+=head1 UNIQUE CONSTRAINTS
+
+=head2 C<id_unique>
+
+=over 4
+
+=item * L</id>
+
+=back
+
+=cut
+
+__PACKAGE__->add_unique_constraint("id_unique", ["id"]);
 
 =head1 RELATIONS
 
@@ -352,8 +373,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-09 13:03:05
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ivYvsUyhEeaeI4EmRQ0/QQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-05 14:04:10
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:nYCuDZ8kEfmtUTbq4HGA1Q
 
 my %hint = (
     columns => [

--- a/src/script/hydra-backfill-ids
+++ b/src/script/hydra-backfill-ids
@@ -1,0 +1,118 @@
+#! /usr/bin/env perl
+
+use strict;
+use utf8;
+use Hydra::Model::DB;
+
+STDOUT->autoflush();
+STDERR->autoflush(1);
+binmode STDERR, ":encoding(utf8)";
+
+my $db = Hydra::Model::DB->new();
+my $vacuum = $db->storage->dbh->prepare("VACUUM;");
+
+my $dryRun = defined $ENV{'HYDRA_DRY_RUN'};
+
+my $batchSize = 10000;
+my $iterationsPerVacuum = 10;
+
+sub backfillJobsJobsetId {
+    print STDERR "Backfilling Jobs records where jobset_id is NULL...\n";
+
+    my $totalToGoSth = $db->storage->dbh->prepare(<<QUERY);
+SELECT COUNT(*) FROM jobs WHERE jobset_id IS NULL
+QUERY
+
+    $totalToGoSth->execute();
+    my ($totalToGo) = $totalToGoSth->fetchrow_array;
+
+    my $update10kJobs = $db->storage->dbh->prepare(<<QUERY);
+UPDATE jobs
+SET jobset_id = (
+  SELECT jobsets.id
+  FROM jobsets
+  WHERE jobsets.name = jobs.jobset
+    AND jobsets.project = jobs.project
+)
+WHERE (jobs.project, jobs.jobset, jobs.name) in (
+  SELECT jobsprime.project, jobsprime.jobset, jobsprime.name
+  FROM jobs jobsprime
+  WHERE jobsprime.jobset_id IS NULL
+  FOR UPDATE SKIP LOCKED
+  LIMIT ?
+);
+QUERY
+
+    print STDERR "Total Jobs records without a jobset_id: $totalToGo\n";
+
+    my $iteration = 0;
+    my $affected;
+    do {
+        $iteration++;
+        $affected = $update10kJobs->execute($batchSize);
+        print STDERR "(batch #$iteration; $totalToGo remaining) Jobs.jobset_id: affected $affected rows...\n";
+        $totalToGo -= $affected;
+
+        if ($iteration % $iterationsPerVacuum == 0) {
+            print STDERR "(batch #$iteration) Vacuuming...\n";
+            $vacuum->execute();
+        }
+    } while ($affected > 0);
+}
+
+
+sub backfillBuildsJobsetId {
+    print STDERR "Backfilling Builds records where jobset_id is NULL...\n";
+
+    my $totalToGoSth = $db->storage->dbh->prepare(<<QUERY);
+SELECT COUNT(*) FROM builds WHERE jobset_id IS NULL
+QUERY
+
+    $totalToGoSth->execute();
+    my ($totalToGo) = $totalToGoSth->fetchrow_array;
+
+    my $update10kBuilds = $db->storage->dbh->prepare(<<QUERY);
+UPDATE builds
+SET jobset_id = (
+  SELECT jobsets.id
+  FROM jobsets
+  WHERE jobsets.name = builds.jobset
+    AND jobsets.project = builds.project
+)
+WHERE builds.id in (
+  SELECT buildprime.id
+  FROM builds buildprime
+  WHERE buildprime.jobset_id IS NULL
+  ORDER BY buildprime.id
+  FOR UPDATE SKIP LOCKED
+  LIMIT ?
+);
+QUERY
+
+    print STDERR "Total Builds records without a jobset_id: $totalToGo\n";
+
+    my $iteration = 0;
+    my $affected;
+    do {
+        $iteration++;
+        $affected = $update10kBuilds->execute($batchSize);
+        print STDERR "(batch #$iteration; $totalToGo remaining) Builds.jobset_id: affected $affected rows...\n";
+        $totalToGo -= $affected;
+
+        if ($iteration % $iterationsPerVacuum == 0) {
+            print STDERR "(batch #$iteration) Vacuuming...\n";
+            $vacuum->execute();
+        }
+    } while ($affected > 0);
+}
+
+die "syntax: $0\n" unless @ARGV == 0;
+
+print STDERR "Beginning with a VACUUM\n";
+$vacuum->execute();
+
+backfillJobsJobsetId();
+backfillBuildsJobsetId();
+
+print STDERR "Ending with a VACUUM\n";
+$vacuum->execute();

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -143,7 +143,7 @@ sub fetchInputSystemBuild {
     $jobsetName ||= $jobset->name;
 
     my @latestBuilds = $db->resultset('LatestSucceededForJob')
-        ->search({}, {bind => [$projectName, $jobsetName, $jobName]});
+        ->search({}, {bind => [$jobsetName, $jobName]});
 
     my @validBuilds = ();
     foreach my $build (@latestBuilds) {

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -417,7 +417,12 @@ sub checkBuild {
     my $build;
 
     txn_do($db, sub {
-        my $job = $jobset->jobs->update_or_create({ name => $jobName });
+        my $job = $jobset->jobs->update_or_create({
+            name => $jobName,
+            jobset_id => $jobset->id,
+            project => $jobset->project,
+            jobset => $jobset->name,
+        });
 
         # Don't add a build that has already been scheduled for this
         # job, or has been built but is still a "current" build for

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -469,6 +469,7 @@ sub checkBuild {
         # Add the build to the database.
         $build = $job->builds->create(
             { timestamp => $time
+            , jobset_id => $jobset->id
             , description => null($buildInfo->{description})
             , license => null($buildInfo->{license})
             , homepage => null($buildInfo->{homepage})

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -166,6 +166,7 @@ create table Builds (
     -- Info about the inputs.
     project       text not null,
     jobset        text not null,
+    jobset_id     integer null,
     job           text not null,
 
     -- Info about the build result.
@@ -231,6 +232,7 @@ create table Builds (
     check (finished = 0 or (stoptime is not null and stoptime != 0)),
     check (finished = 0 or (starttime is not null and starttime != 0)),
 
+    foreign key (jobset_id) references Jobsets(id) on delete cascade,
     foreign key (project) references Projects(name) on update cascade,
     foreign key (project, jobset) references Jobsets(project, name) on update cascade,
     foreign key (project, jobset, job) references Jobs(project, jobset, name) on update cascade

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -166,7 +166,7 @@ create table Builds (
     -- Info about the inputs.
     project       text not null,
     jobset        text not null,
-    jobset_id     integer null,
+    jobset_id     integer not null,
     job           text not null,
 
     -- Info about the build result.

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -52,6 +52,7 @@ create table ProjectMembers (
 -- describing build jobs.
 create table Jobsets (
     name          text not null,
+    id            serial not null,
     project       text not null,
     description   text,
     nixExprInput  text not null, -- name of the jobsetInput containing the Nix or Guix expression
@@ -72,7 +73,8 @@ create table Jobsets (
     startTime     integer, -- if jobset is currently running
     check (schedulingShares > 0),
     primary key   (project, name),
-    foreign key   (project) references Projects(name) on delete cascade on update cascade
+    foreign key   (project) references Projects(name) on delete cascade on update cascade,
+    constraint    Jobsets_id_unique UNIQUE(id)
 #ifdef SQLITE
     ,
     foreign key   (project, name, nixExprInput) references JobsetInputs(project, jobset, name)

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -142,9 +142,11 @@ create table JobsetInputAlts (
 create table Jobs (
     project       text not null,
     jobset        text not null,
+    jobset_id     integer null,
     name          text not null,
 
     primary key   (project, jobset, name),
+    foreign key   (jobset_id) references Jobsets(id) on delete cascade,
     foreign key   (project) references Projects(name) on delete cascade on update cascade,
     foreign key   (project, jobset) references Jobsets(project, name) on delete cascade on update cascade
 );

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -142,7 +142,7 @@ create table JobsetInputAlts (
 create table Jobs (
     project       text not null,
     jobset        text not null,
-    jobset_id     integer null,
+    jobset_id     integer not null,
     name          text not null,
 
     primary key   (project, jobset, name),

--- a/src/sql/upgrade-58.sql
+++ b/src/sql/upgrade-58.sql
@@ -1,0 +1,4 @@
+-- will automatically add unique IDs to Jobsets.
+ALTER TABLE Jobsets
+  ADD COLUMN id SERIAL NOT NULL,
+  ADD CONSTRAINT Jobsets_id_unique UNIQUE (id);

--- a/src/sql/upgrade-59.sql
+++ b/src/sql/upgrade-59.sql
@@ -1,0 +1,10 @@
+-- Add the jobset_id columns to the Builds table. This will go
+-- quickly, since the field is nullable. Note this is just part one of
+-- this migration. Future steps involve a piecemeal backfilling, and
+-- then making the column non-null.
+
+ALTER TABLE Builds
+  ADD COLUMN jobset_id integer NULL,
+  ADD FOREIGN KEY (jobset_id)
+      REFERENCES Jobsets(id)
+      ON DELETE CASCADE;

--- a/src/sql/upgrade-60.sql
+++ b/src/sql/upgrade-60.sql
@@ -1,0 +1,10 @@
+-- Add the jobset_id columns to the Jobs table. This will go
+-- quickly, since the field is nullable. Note this is just part one of
+-- this migration. Future steps involve a piecemeal backfilling, and
+-- then making the column non-null.
+
+ALTER TABLE Jobs
+  ADD COLUMN jobset_id integer NULL,
+  ADD FOREIGN KEY (jobset_id)
+      REFERENCES Jobsets(id)
+      ON DELETE CASCADE;

--- a/src/sql/upgrade-61.sql
+++ b/src/sql/upgrade-61.sql
@@ -1,0 +1,7 @@
+-- Make the Jobs.jobset_id column NOT NULL. If this upgrade fails,
+-- either the admin didn't run the backfiller or there is a bug. If
+-- the admin ran the backfiller and there are null columns, it is
+-- very important to figure out where the nullable columns came from.
+
+ALTER TABLE Jobs
+  ALTER COLUMN jobset_id SET NOT NULL;

--- a/src/sql/upgrade-62.sql
+++ b/src/sql/upgrade-62.sql
@@ -1,0 +1,7 @@
+-- Make the Builds.jobset_id column NOT NULL. If this upgrade fails,
+-- either the admin didn't run the backfiller or there is a bug. If
+-- the admin ran the backfiller and there are null columns, it is
+-- very important to figure out where the nullable columns came from.
+
+ALTER TABLE Builds
+  ALTER COLUMN jobset_id SET NOT NULL;


### PR DESCRIPTION
Implement all but the backfill steps of:

1. Add an `id` to the `Jobsets` table: serial, non-null, unique. 
    - Fast.
    - Postgresql will automatically backfill, and new writes will automatically have them too.
    - Code changes: None. Fully backwards and forward compatible.
2. Add a `jobset_id` to the Jobs table: nullable, foreign key to `Jobsets`
    - Fast.
    - Code changes:
        - All places writing to `Jobs` should begin writing the `jobset_id`
            - I believe there is only one place:
            - [https://github.com/NixOS/hydra/blob/9da60e3c66430eb82f06f2f369e9df7e584b344f/src/script/hydra-eval-jobset#L420](https://github.com/NixOS/hydra/blob/9da60e3c66430eb82f06f2f369e9df7e584b344f/src/script/hydra-eval-jobset#L420)
3. Add a `jobset_id` to the `Builds` table: nullable, foreign key to `Jobsets` (`3f074388`)
    - Fast.
    - Code changes:
        - All places writing to `Builds` should begin writing the `jobset_id`
            - I believe there is only one place:
            - [https://github.com/NixOS/hydra/blob/9da60e3c66430eb82f06f2f369e9df7e584b344f/src/script/hydra-eval-jobset#L465](https://github.com/NixOS/hydra/blob/9da60e3c66430eb82f06f2f369e9df7e584b344f/src/script/hydra-eval-jobset#L465) (`52283da9`)
4. Backfill `Jobs` with `jobset_id` values.
    1. The naive way to backfill has many problems:
        1. Very slow
        2. Huge amount of time with a read lock.
        3. Rewrites the entire table on disk in one shot, causing a full 2x table bloat
    2. Solution:
        - Create a purpose-built tool to incrementally backfill the table:
            1. running this in a loop:

                    UPDATE jobs
                    SET jobset_id = (
                      SELECT jobsets.id
                      FROM jobsets
                      WHERE jobsets.name = jobs.jobset
                        AND jobsets.project = jobs.project
                    )
                    WHERE jobs.id in (
                      SELECT jobsprime.id
                      FROM jobs jobsprime
                      WHERE jobsprime.jobset_id IS NULL
                      FOR UPDATE SKIP LOCKED
                      LIMIT 10000
                    );

            2. Every N iterations, run `VACUUM` 
        - Hydra can stay fully online during the entire migration
        - The subselect of a specific collection of IDs allows the write lock to only affect those rows.
        - `VACUUM` will prevent 2x table bloat from happening all at once
5. Backfill `Builds` with `jobset_id` values.
    1. The naive way to backfill has many problems:
        1. Very slow
        2. Huge amount of time with a read lock.
        3. Rewrites the entire table on disk in one shot, causing a full 2x table bloat
    2. Solution:
        - Create a purpose-built tool to incrementally backfill the table:
            1. running this in a loop:

                    UPDATE builds
                    SET jobset_id = (
                      SELECT jobsets.id
                      FROM jobsets
                      WHERE jobsets.name = builds.jobset
                        AND jobsets.project = builds.project
                    )
                    WHERE builds.id in (
                      SELECT buildprime.id
                      FROM builds buildprime
                      WHERE buildprime.jobset_id IS NULL
                      ORDER BY buildprime.id
                      FOR UPDATE SKIP LOCKED
                      LIMIT 10000
                    );

            2. Every N iterations, run `VACUUM` 
        - Hydra can stay fully online during the entire migration
        - The subselect of a specific collection of IDs allows the write lock to only affect those rows.
        - `VACUUM` will prevent 2x table bloat from happening all at once
6. Perform an explicit release and put this in to production, and run the backfill tool until all rows are updated.
    1. Monitor to see if new Builds or Jobs rows are added with null `jobset_id` fields, this would indicate a bug which needs to be fixed.
7. Modify the `Builds` table, doing two things in one transaction:
    1. Assert that there are no rows with a null `jobset_id`, any rows with a null `jobset_id` is likely from a bug we should fix.
    2. Alter the `Builds` table to make  `jobset_id` not-null. Hopefully not very slow, I think postgresql will only validate no rows have a null `jobset_id`.
8. Modify the `Jobs` table, doing two things in one transaction:
    1. Assert that there are no rows with a null `jobset_id`, any rows with a null `jobset_id` is likely from a bug we should fix.
    2. Alter the `Jobs` table to make  `jobset_id` not-null. Hopefully not very slow, I think postgresql will only validate no rows have a null `jobset_id`.
9. Alter the read paths to read through the `jobset_id` field for Builds and Jobs.